### PR TITLE
[patch-axel-7] support compiling with clang

### DIFF
--- a/.github/workflows/sel4bench-pr.yml
+++ b/.github/workflows/sel4bench-pr.yml
@@ -44,16 +44,18 @@ jobs:
       fail-fast: false
       matrix:
         march: [armv7a, armv8a, nehalem, rv64imac]
+        compiler: [gcc, clang]
     steps:
     - name: Build
       uses: seL4/ci-actions/sel4bench@master
       with:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
+        compiler: ${{ matrix.compiler }}
     - name: Upload images
       uses: actions/upload-artifact@v4
       with:
-        name: images-${{ matrix.march }}
+        name: images-${{ matrix.march }}-${{matrix.compiler}}
         path: '*-images.tar.gz'
 
   hw-run:
@@ -100,7 +102,7 @@ jobs:
       - name: Download image
         uses: actions/download-artifact@v4
         with:
-          name: images-${{ steps.plat.outputs.march }}
+          name: images-${{ steps.plat.outputs.march }}-${{matrix.compiler}}
       - name: Run
         uses: seL4/ci-actions/sel4bench-hw@master
         with:
@@ -113,5 +115,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # funky expression below is to work around lack of ternary operator
-          name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}
+          name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}-${{matrix.compiler}}
           path: '*.json'

--- a/.github/workflows/sel4bench.yml
+++ b/.github/workflows/sel4bench.yml
@@ -40,16 +40,18 @@ jobs:
       fail-fast: false
       matrix:
         march: [armv7a, armv8a, nehalem, rv64imac]
+        compiler: [gcc, clang]
     steps:
     - name: Build
       uses: seL4/ci-actions/sel4bench@master
       with:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
+        compiler: ${{ matrix.compiler }}
     - name: Upload images
       uses: actions/upload-artifact@v4
       with:
-        name: images-${{ matrix.march }}
+        name: images-${{ matrix.march }}-${{matrix.compiler}}
         path: '*-images.tar.gz'
 
   hw-run:
@@ -90,7 +92,7 @@ jobs:
       - name: Download image
         uses: actions/download-artifact@v4
         with:
-          name: images-${{ steps.plat.outputs.march }}
+          name: images-${{ steps.plat.outputs.march }}-${{matrix.compiler}}
       - name: Run
         uses: seL4/ci-actions/sel4bench-hw@master
         with:
@@ -103,7 +105,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # funky expression below is to work around lack of ternary operator
-          name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}
+          name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}-${{matrix.compiler}}
           path: '*.json'
 
   deploy:
@@ -128,23 +130,23 @@ jobs:
     - name: Get results for web deployment (sabre)
       uses: actions/download-artifact@v4
       with:
-        name: sel4bench-results-sabre
+        name: sel4bench-results-sabre-gcc
     - name: Get results for web deployment (haswell)
       uses: actions/download-artifact@v4
       with:
-        name: sel4bench-results-pc99-haswell3
+        name: sel4bench-results-pc99-haswell3-gcc
     - name: Get results for web deployment (skylake)
       uses: actions/download-artifact@v4
       with:
-        name: sel4bench-results-pc99-skylake
+        name: sel4bench-results-pc99-skylake-gcc
     - name: Get results for web deployment (tx1)
       uses: actions/download-artifact@v4
       with:
-        name: sel4bench-results-tx1
+        name: sel4bench-results-tx1-gcc
     - name: Get results for web deployment (hifive)
       uses: actions/download-artifact@v4
       with:
-        name: sel4bench-results-hifive
+        name: sel4bench-results-hifive-gcc
     - name: Generate web page
       uses: seL4/ci-actions/sel4bench-web@master
       with:

--- a/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/fault.h
+++ b/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/fault.h
@@ -38,5 +38,5 @@
 } while(0)
 #endif /* CONFIG_KERNEL_MCS */
 
-#define DO_REAL_REPLY_RECV_1(ep, mr0, ro) DO_REPLY_RECV_1(ep, mr0, ro, "swi $0")
+#define DO_REAL_REPLY_RECV_1(ep, mr0, ro) DO_REPLY_RECV_1(ep, mr0, ro, "swi #0")
 #define DO_NOP_REPLY_RECV_1(ep, mr0, ro)  DO_REPLY_RECV_1(ep, mr0, ro, "nop")

--- a/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/hardware.h
+++ b/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/hardware.h
@@ -14,5 +14,5 @@
     ); \
 } while (0);
 
-#define DO_REAL_NULLSYSCALL()     DO_NULLSYSCALL("swi $0")
+#define DO_REAL_NULLSYSCALL()     DO_NULLSYSCALL("swi #0")
 #define DO_NOP_NULLSYSCALL()      DO_NULLSYSCALL("nop")

--- a/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/ipc.h
+++ b/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/ipc.h
@@ -106,16 +106,16 @@
 } while(0)
 #endif /* CONFIG_KERNEL_MCS */
 
-#define DO_REAL_CALL(ep, tag) DO_CALL(ep, tag, "swi $0")
+#define DO_REAL_CALL(ep, tag) DO_CALL(ep, tag, "swi #0")
 #define DO_NOP_CALL(ep, tag) DO_CALL(ep, tag, "nop")
-#define DO_REAL_CALL_10(ep, tag) DO_CALL_10(ep, tag, "swi $0")
+#define DO_REAL_CALL_10(ep, tag) DO_CALL_10(ep, tag, "swi #0")
 #define DO_NOP_CALL_10(ep, tag) DO_CALL_10(ep, tag, "nop")
-#define DO_REAL_SEND(ep, tag) DO_SEND(ep, tag, "swi $0")
+#define DO_REAL_SEND(ep, tag) DO_SEND(ep, tag, "swi #0")
 #define DO_NOP_SEND(ep, tag) DO_SEND(ep, tag, "nop")
 
-#define DO_REAL_REPLY_RECV(ep, tag, ro) DO_REPLY_RECV(ep, tag, ro, "swi $0")
+#define DO_REAL_REPLY_RECV(ep, tag, ro) DO_REPLY_RECV(ep, tag, ro, "swi #0")
 #define DO_NOP_REPLY_RECV(ep, tag, ro) DO_REPLY_RECV(ep, tag, ro, "nop")
-#define DO_REAL_REPLY_RECV_10(ep, tag, ro) DO_REPLY_RECV_10(ep, tag, ro, "swi $0")
+#define DO_REAL_REPLY_RECV_10(ep, tag, ro) DO_REPLY_RECV_10(ep, tag, ro, "swi #0")
 #define DO_NOP_REPLY_RECV_10(ep, tag, ro) DO_REPLY_RECV_10(ep, tag, ro, "nop")
-#define DO_REAL_RECV(ep, ro) DO_RECV(ep, ro, "swi $0")
+#define DO_REAL_RECV(ep, ro) DO_RECV(ep, ro, "swi #0")
 #define DO_NOP_RECV(ep, ro) DO_RECV(ep, ro, "nop")

--- a/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/signal.h
+++ b/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/signal.h
@@ -24,7 +24,7 @@
 #endif
 #define DO_SIGNAL(ntfn, swi) DO_NTFN_OP(ntfn, swi, seL4_SysSend)
 
-#define DO_REAL_WAIT(ntfn)       DO_WAIT(ntfn, "swi $0")
+#define DO_REAL_WAIT(ntfn)       DO_WAIT(ntfn, "swi #0")
 #define DO_NOP_WAIT(ntfn)        DO_WAIT(ntfn, "nop")
-#define DO_REAL_SIGNAL(ntfn)     DO_SIGNAL(ntfn, "swi $0")
+#define DO_REAL_SIGNAL(ntfn)     DO_SIGNAL(ntfn, "swi #0")
 #define DO_NOP_SIGNAL(ntfn)      DO_SIGNAL(ntfn, "nop")

--- a/settings.cmake
+++ b/settings.cmake
@@ -64,7 +64,14 @@ if(NOT Sel4benchAllowSettingsOverride)
     # This option is controlled by ApplyCommonReleaseVerificationSettings
     mark_as_advanced(CMAKE_BUILD_TYPE)
     if(RELEASE)
-        if(NOT KernelArchRiscV)
+        # Known issues with KernelFWholeProgram ('-fwhole-program'):
+        # - the RISC-V kernel build with gcc currently fails due to a missing
+        #   compiler runtime helper function.
+        # - this option is not supposed by 'clang' at all. Note that we can't
+        #   check CMAKE_C_COMPILER_ID here, because it is empty, as this file
+        #   might get processed before CMake does any compiler evaluation. Thus,
+        #   the only option is checking if TRIPLE is set or not.
+        if((NOT KernelArchRiscV) AND (TRIPLE STREQUAL ""))
             set(KernelFWholeProgram ON CACHE BOOL "" FORCE)
         endif()
     endif()


### PR DESCRIPTION
ToDo: look into kernel build failure:
```
[64/253] Linking C executable kernel/kernel.elf
  FAILED: kernel/kernel.elf
  : && /usr/bin/ccache /usr/bin/riscv64-unknown-elf-gcc --sysroot=/github/workspace/build -D__KERNEL_64__ -march=rv64imac -mabi=lp64 -O3 -DNDEBUG -D__KERNEL_64__ -march=rv64imac -mabi=lp64   -static -Wl,--build-id=none -Wl,-n -O2  -nostdlib  -fno-pic  -fno-pie  -fwhole-program  -mcmodel=medany  -msmall-data-limit=1024     -Wl,-T /github/workspace/build/kernel/linker.lds_pp kernel/CMakeFiles/kernel.elf.dir/src/arch/riscv/head.S.obj kernel/CMakeFiles/kernel.elf.dir/src/arch/riscv/traps.S.obj kernel/CMakeFiles/kernel.elf.dir/kernel_all.c.obj -o kernel/kernel.elf   && :
  /usr/lib/riscv64-unknown-elf/bin/ld: kernel/CMakeFiles/kernel.elf.dir/kernel_all.c.obj: in function `.L340':
  kernel_all.c:(.text+0xa54): undefined reference to `__clzdi2'
  /usr/lib/riscv64-unknown-elf/bin/ld: kernel/CMakeFiles/kernel.elf.dir/kernel_all.c.obj: in function `.L342':
  kernel_all.c:(.text+0xa70): undefined reference to `__clzdi2'
  /usr/lib/riscv64-unknown-elf/bin/ld: kernel/CMakeFiles/kernel.elf.dir/kernel_all.c.obj: in function `.L0 ':
  kernel_all.c:(.text+0xb6a): undefined reference to `__clzdi2'
  /usr/lib/riscv64-unknown-elf/bin/ld: kernel/CMakeFiles/kernel.elf.dir/kernel_all.c.obj: in function `schedule':
  kernel_all.c:(.text+0xb88): undefined reference to `__clzdi2'
  /usr/lib/riscv64-unknown-elf/bin/ld: kernel/CMakeFiles/kernel.elf.dir/kernel_all.c.obj: in function `create_untypeds_for_region':
  kernel_all.c:(.boot.text+0x360): undefined reference to `__clzdi2'
  /usr/lib/riscv64-unknown-elf/bin/ld: kernel_all.c:(.boot.text+0x3f4): undefined reference to `__ctzdi2'
  /usr/lib/riscv64-unknown-elf/bin/ld: kernel/CMakeFiles/kernel.elf.dir/kernel_all.c.obj: in function `.L423':
  kernel_all.c:(.boot.text+0x4e2): undefined reference to `__clzdi2'
  /usr/lib/riscv64-unknown-elf/bin/ld: kernel/CMakeFiles/kernel.elf.dir/kernel_all.c.obj: in function `.L2281':
  kernel_all.c:(.text.fastpath+0x[162](https://github.com/axel-h/sel4bench/actions/runs/8618957355/job/23622562006?pr=9#step:3:164)): undefined reference to `__clzdi2'
  /usr/lib/riscv64-unknown-elf/bin/ld: kernel/CMakeFiles/kernel.elf.dir/kernel_all.c.obj: in function `.L2282':
  kernel_all.c:(.text.fastpath+0x17e): undefined reference to `__clzdi2'
  /usr/lib/riscv64-unknown-elf/bin/ld: kernel/CMakeFiles/kernel.elf.dir/kernel_all.c.obj: in function `.L0 ':
  kernel_all.c:(.text.fastpath+0x5d0): undefined reference to `__clzdi2'
  /usr/lib/riscv64-unknown-elf/bin/ld: kernel_all.c:(.text.fastpath+0x5ec): undefined reference to `__clzdi2'
  collect2: error: ld returned 1 exit status
```