### PR TITLE
[patch-axel-9] arm: avoid attic assembly syntax

### DIFF
--- a/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/fault.h
+++ b/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/fault.h
@@ -38,5 +38,5 @@
 } while(0)
 #endif /* CONFIG_KERNEL_MCS */
 
-#define DO_REAL_REPLY_RECV_1(ep, mr0, ro) DO_REPLY_RECV_1(ep, mr0, ro, "swi $0")
+#define DO_REAL_REPLY_RECV_1(ep, mr0, ro) DO_REPLY_RECV_1(ep, mr0, ro, "swi #0")
 #define DO_NOP_REPLY_RECV_1(ep, mr0, ro)  DO_REPLY_RECV_1(ep, mr0, ro, "nop")

--- a/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/hardware.h
+++ b/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/hardware.h
@@ -14,5 +14,5 @@
     ); \
 } while (0);
 
-#define DO_REAL_NULLSYSCALL()     DO_NULLSYSCALL("swi $0")
+#define DO_REAL_NULLSYSCALL()     DO_NULLSYSCALL("swi #0")
 #define DO_NOP_NULLSYSCALL()      DO_NULLSYSCALL("nop")

--- a/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/ipc.h
+++ b/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/ipc.h
@@ -106,16 +106,16 @@
 } while(0)
 #endif /* CONFIG_KERNEL_MCS */
 
-#define DO_REAL_CALL(ep, tag) DO_CALL(ep, tag, "swi $0")
+#define DO_REAL_CALL(ep, tag) DO_CALL(ep, tag, "swi #0")
 #define DO_NOP_CALL(ep, tag) DO_CALL(ep, tag, "nop")
-#define DO_REAL_CALL_10(ep, tag) DO_CALL_10(ep, tag, "swi $0")
+#define DO_REAL_CALL_10(ep, tag) DO_CALL_10(ep, tag, "swi #0")
 #define DO_NOP_CALL_10(ep, tag) DO_CALL_10(ep, tag, "nop")
-#define DO_REAL_SEND(ep, tag) DO_SEND(ep, tag, "swi $0")
+#define DO_REAL_SEND(ep, tag) DO_SEND(ep, tag, "swi #0")
 #define DO_NOP_SEND(ep, tag) DO_SEND(ep, tag, "nop")
 
-#define DO_REAL_REPLY_RECV(ep, tag, ro) DO_REPLY_RECV(ep, tag, ro, "swi $0")
+#define DO_REAL_REPLY_RECV(ep, tag, ro) DO_REPLY_RECV(ep, tag, ro, "swi #0")
 #define DO_NOP_REPLY_RECV(ep, tag, ro) DO_REPLY_RECV(ep, tag, ro, "nop")
-#define DO_REAL_REPLY_RECV_10(ep, tag, ro) DO_REPLY_RECV_10(ep, tag, ro, "swi $0")
+#define DO_REAL_REPLY_RECV_10(ep, tag, ro) DO_REPLY_RECV_10(ep, tag, ro, "swi #0")
 #define DO_NOP_REPLY_RECV_10(ep, tag, ro) DO_REPLY_RECV_10(ep, tag, ro, "nop")
-#define DO_REAL_RECV(ep, ro) DO_RECV(ep, ro, "swi $0")
+#define DO_REAL_RECV(ep, ro) DO_RECV(ep, ro, "swi #0")
 #define DO_NOP_RECV(ep, ro) DO_RECV(ep, ro, "nop")

--- a/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/signal.h
+++ b/libsel4benchsupport/sel4_arch_include/aarch32/sel4_arch/signal.h
@@ -24,7 +24,7 @@
 #endif
 #define DO_SIGNAL(ntfn, swi) DO_NTFN_OP(ntfn, swi, seL4_SysSend)
 
-#define DO_REAL_WAIT(ntfn)       DO_WAIT(ntfn, "swi $0")
+#define DO_REAL_WAIT(ntfn)       DO_WAIT(ntfn, "swi #0")
 #define DO_NOP_WAIT(ntfn)        DO_WAIT(ntfn, "nop")
-#define DO_REAL_SIGNAL(ntfn)     DO_SIGNAL(ntfn, "swi $0")
+#define DO_REAL_SIGNAL(ntfn)     DO_SIGNAL(ntfn, "swi #0")
 #define DO_NOP_SIGNAL(ntfn)      DO_SIGNAL(ntfn, "nop")


### PR DESCRIPTION
Clang does not support the attic syntax.